### PR TITLE
Feat/random goals and additionnal channel

### DIFF
--- a/agentLocal.py
+++ b/agentLocal.py
@@ -63,6 +63,8 @@ class DFPAgent():
       self.explore = args["explore"] 
       self.frame_per_action = args["frame_per_action"]
       self.timestep_per_train = args["timestep_per_train"] # Number of timesteps between training interval
+      self.evaluate_freq = args["agent_evaluate_freq"]
+      self.nb_evaluation_episodes = args["nb_evaluation_episodes"]
 
       # experience replay buffer
       self.memory = deque()

--- a/agentLocal.py
+++ b/agentLocal.py
@@ -74,11 +74,13 @@ class DFPAgent():
       if self.use_cuda :
           self.model = self.model.cuda()
     
-    def get_action(self, state, measurement, goal, inference_goal):
+    def get_action(self, state, measurement, goal, inference_goal, epsilon=None):
         """
         Get action from model using epsilon-greedy policy
         """
-        if np.random.rand() <= self.epsilon:
+        if epsilon is None:
+            epsilon=self.epsilon
+        if np.random.rand() <= epsilon:
             #print("----------Random Action----------")
             action_idx = random.randrange(self.action_size)
         else:

--- a/default_parameters.py
+++ b/default_parameters.py
@@ -51,10 +51,11 @@ def update_default_args(args):
         "CHANNEL_NAMES" : ["left_team", 'right_team', 'left_team_direction', 'right_team_direction', 'ball', 'ball_direction', "current_player"],
         "MEASUREMENT_NAMES" : ['goals', 'ball_distance_to_goal', "ball_distance_to_center", "possession"],
         "TIMESTEPS" : [1,2,4,8,16,32],
+        "timesteps_goal": [0,0,0,0.5,0.5,1],
         "IMAGE_SIZE" : (43, 101),
         "NB_ACTIONS" : 19,
         "RANDOM_TRAIN_GOAL": False, #If false, train goal is equal to eval goal
-        "EVAL_GOAL": [10,0.2,0.1,2]
+        "EVAL_GOAL": [10,0.2,0.1,2],
     })
 
         # Save update
@@ -82,7 +83,7 @@ def update_default_args(args):
         "timestep_per_train" : 64,
         "max_memory" : 20000,
         "agent_evaluate_freq": 5000,
-        "nb_evaluation_episodes": 20 #is that too much / too little (depends on scenario)
+        "nb_evaluation_episodes": 20 #is that too much / too little (depends on scenario),
     })
 
 

--- a/default_parameters.py
+++ b/default_parameters.py
@@ -53,6 +53,8 @@ def update_default_args(args):
         "TIMESTEPS" : [1,2,4,8,16,32],
         "IMAGE_SIZE" : (43, 101),
         "NB_ACTIONS" : 19,
+        "RANDOM_TRAIN_GOAL": False, #If false, train goal is equal to eval goal
+        "EVAL_GOAL": [10,0.2,0.1,2]
     })
 
         # Save update
@@ -79,7 +81,8 @@ def update_default_args(args):
         "frame_per_action" : 1, # TODO : USELESS ?
         "timestep_per_train" : 64,
         "max_memory" : 20000,
-
+        "agent_evaluate_freq": 5000,
+        "nb_evaluation_episodes": 20 #is that too much / too little (depends on scenario)
     })
 
 

--- a/default_parameters.py
+++ b/default_parameters.py
@@ -48,7 +48,7 @@ def update_default_args(args):
     # Games update :
     args.update({
         "SCENARIO" : "11_vs_11_kaggle",
-        "CHANNEL_NAMES" : ["left_team", 'right_team', 'left_team_direction', 'right_team_direction', 'ball', 'ball_direction'],
+        "CHANNEL_NAMES" : ["left_team", 'right_team', 'left_team_direction', 'right_team_direction', 'ball', 'ball_direction', "current_player"],
         "MEASUREMENT_NAMES" : ['goals', 'ball_distance_to_goal', "ball_distance_to_center", "possession"],
         "TIMESTEPS" : [1,2,4,8,16,32],
         "IMAGE_SIZE" : (43, 101),

--- a/run_exp.py
+++ b/run_exp.py
@@ -48,4 +48,5 @@ if __name__ == '__main__':
         utils.load_model(dfp_agent, optimizer, scheduler, args)
 
     env = make("football", configuration={"save_video": args["SAVE_VIDEO"], "scenario_name": args["SCENARIO"], "running_in_notebook": args["running_in_notebook"], "episodeSteps": args["env_num_steps"]}, debug=args["DEBUG"])
-    train(dfp_agent, env, optimizer, scheduler, args, list_opposition = [oppositionAgent])
+    eval_env = make("football", configuration={"save_video": args["SAVE_VIDEO"], "scenario_name": args["SCENARIO"], "running_in_notebook": args["running_in_notebook"], "episodeSteps": args["env_num_steps"]}, debug=args["DEBUG"])
+    train(dfp_agent, env, eval_env, optimizer, scheduler, args, list_opposition = [oppositionAgent])

--- a/train.py
+++ b/train.py
@@ -33,10 +33,10 @@ def train(dfp_agent, env, eval_env, optimizer, scheduler, args, list_opposition)
   score_buffer = []
   r_t = 0
   if args['RANDOM_TRAIN_GOAL']:
-    goal = utils.create_last_timestep_goal(list(np.random.rand(len(MEASUREMENT_NAMES))), len(args["TIMESTEPS"]))
+    goal = utils.create_goal(list(np.random.rand(len(MEASUREMENT_NAMES))), args["timesteps_goal"])
   else:
-    goal = utils.create_last_timestep_goal(args['EVAL_GOAL'], len(args["TIMESTEPS"]))
-  eval_goal = utils.create_last_timestep_goal(args['EVAL_GOAL'], len(args["TIMESTEPS"]))
+    goal = utils.create_goal(args['EVAL_GOAL'], args["timesteps_goal"])
+  eval_goal = utils.create_goal(args['EVAL_GOAL'], args["timesteps_goal"])
   loss = 0
   loss_queue_size = 50
   loss_queue = []
@@ -64,7 +64,7 @@ def train(dfp_agent, env, eval_env, optimizer, scheduler, args, list_opposition)
         print ("Episode Finished ")
         observation = env.reset()
         if args['RANDOM_TRAIN_GOAL']:
-          goal = utils.create_last_timestep_goal(list(np.random.rand(len(MEASUREMENT_NAMES))), len(args["TIMESTEPS"]))
+          goal = utils.create_goal(list(np.random.rand(len(MEASUREMENT_NAMES))), args["timesteps_goal"])
     
     # save the sample <s, a, r, s'> to the replay memory and decrease epsilon
     dfp_agent.replay_memory(t, sensory, action_dfp, r_t, None, measurements, is_terminated)
@@ -104,8 +104,8 @@ def train(dfp_agent, env, eval_env, optimizer, scheduler, args, list_opposition)
         eval_rewards.append(eval_observation[0]['reward'])
         episode_lengths.append(episode_length)
         #TODO: save logs of evaluation
-      print(eval_rewards)
-      print(episode_lengths)
+      print("eval_rewards",eval_rewards)
+      print("episode length", episode_lengths)
 
     # print info
     state = ""

--- a/train.py
+++ b/train.py
@@ -29,8 +29,6 @@ def train(dfp_agent, env, optimizer, scheduler, args, list_opposition):
   ## Training loop
   while t_observe<dfp_agent.observe or t<args["total_train"]:
 
-    
-
     action_op = agent.get_action(observation[1]['observation'])
 
     frame_data = observation[0]["observation"]["players_raw"][0]
@@ -42,13 +40,7 @@ def train(dfp_agent, env, optimizer, scheduler, args, list_opposition):
       
 
     action_dfp = dfp_agent.get_action(sensory, measurements, goal, goal)
-    try:
-      observation= env.step([[action_dfp],action_op])
-    except Exception as e:
-      print("pre-mortem obs",observation)
-      print(e)
-      done=True
-
+    observation= env.step([[action_dfp],action_op])
 
     ## TODO: Add frame skip between each memory ?
     is_terminated = observation[0]['status'] == "DONE"

--- a/train.py
+++ b/train.py
@@ -18,7 +18,7 @@ def train(dfp_agent, env, optimizer, scheduler, args, list_opposition):
   # Buffer to compute rolling statistics 
   score_buffer = []
   r_t = 0
-  goal = utils.create_goal([10,0.2,0.1,2], len(args["TIMESTEPS"]))
+  goal = utils.create_last_timestep_goal([10,0.2,0.1,2], len(args["TIMESTEPS"]))
   loss = 0
   loss_queue_size = 50
   loss_queue = []

--- a/utils.py
+++ b/utils.py
@@ -122,14 +122,14 @@ def create_scheduler(optimizer,args):
     raise NotImplementedError
   return scheduler
 
-def create_last_timestep_goal(single_timestep_goal, timesteps_size):
+def create_goal(single_timestep_goal, timesteps_goal):
   """
   Create goal with given relative importance of measurements for the LAST timestep to predict (like in the paper)
   """
-  goal = torch.zeros((timesteps_size, len(single_timestep_goal)), dtype=torch.float)
-  goal[-1]=torch.tensor(single_timestep_goal)
-  goal = goal.flatten()
-  return goal
+  temp1 = torch.tensor(single_timestep_goal).repeat((len(timesteps_goal)))
+  temp2 = torch.tensor(timesteps_goal).repeat((4,1)).T.flatten()
+  goal = torch.tensor((single_timestep_goal)).view((-1,1)) * torch.tensor((timesteps_goal)).repeat((len(single_timestep_goal),1))
+  return temp1*temp2
 
 
 def save_model(t, optimizer, scheduler, dfp_agent, path):

--- a/utils.py
+++ b/utils.py
@@ -101,6 +101,7 @@ def raw_data_to_target(episode_data, start_frame, measurement_names, future_time
 
 
 
+
 def create_optimizer(dfp_agent,args):
   if args["optimizer"] == "Adam":
     optimizer = optim.Adam(dfp_agent.model.parameters(), lr = args["lr"])
@@ -118,13 +119,12 @@ def create_scheduler(optimizer,args):
     raise NotImplementedError
   return scheduler
 
-
-def create_goal(rel_goal, timesteps_size):
+def create_last_timestep_goal(single_timestep_goal, timesteps_size):
   """
   Create goal with given relative importance of measurements for the LAST timestep to predict (like in the paper)
   """
-  goal = torch.zeros((timesteps_size, len(rel_goal)), dtype=torch.float)
-  goal[-1]=torch.tensor(rel_goal)
+  goal = torch.zeros((timesteps_size, len(single_timestep_goal)), dtype=torch.float)
+  goal[-1]=torch.tensor(single_timestep_goal)
   goal = goal.flatten()
   return goal
 

--- a/utils.py
+++ b/utils.py
@@ -30,6 +30,9 @@ def frame_data_to_channel(frame_data, channel_name, channel_shape):
     channel[coords_to_pixel(frame_data[channel_name][0] + frame_data['ball'][0],frame_data[channel_name][1] + frame_data['ball'][1], channel_shape)]=1
   elif channel_name == "ball":
     channel[coords_to_pixel(*frame_data[channel_name][:2], channel_shape)]=1
+  elif channel_name=="current_player":
+    active_player = frame_data['active']
+    channel[coords_to_pixel(*frame_data['left_team'][active_player], channel_shape)]=1
   elif 'direction' in channel_name:
     aux_channel_name = channel_name.split('_direction')[0]
     for i in range(len(frame_data[channel_name])):


### PR DESCRIPTION
Features added:
- Additionnal channel for current player controlled by agent
- Random goal at train time
- Evaluation of agent with set goal (to be able to compare between epochs on the same goal)

Refactored:
- Create env_step function for readability of train loop
- Add arguments for random goal
- rename create goal function



TODO:
- Add to logs the evaluation results
- Find pertinent value for nb of evaluation episodes
- Modify timesteps goal like in the paper (the three last timesteps are used) 
- Change length of each episode, in the paper it is 1 minute (525 steps, maybe use same length)